### PR TITLE
Add PostService tests

### DIFF
--- a/tests/Unit/PostServiceTest.php
+++ b/tests/Unit/PostServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\PostRepository;
+use App\Services\PostService;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class PostServiceTest extends TestCase
+{
+    /** @var PostRepository|MockObject */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->createMock(PostRepository::class);
+    }
+
+    public function test_get_all_returns_repository_results()
+    {
+        $expected = ['foo'];
+        $this->repository->expects($this->once())
+            ->method('with')
+            ->with('category')
+            ->willReturnSelf();
+        $this->repository->expects($this->once())
+            ->method('get')
+            ->willReturn($expected);
+
+        $service = new PostService($this->repository);
+        $result = $service->getAll();
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function test_store_creates_post()
+    {
+        $data = ['name' => 'Post', 'description' => 'd', 'content' => 'c', 'cat_id' => 1];
+        $created = (object)$data;
+
+        $this->repository->expects($this->once())
+            ->method('create')
+            ->with($data)
+            ->willReturn($created);
+
+        $service = new PostService($this->repository);
+        $result = $service->store($data);
+
+        $this->assertSame($created, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for PostService

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495b9c287c8325b48d42c8fe503979